### PR TITLE
Fix for BattleTag

### DIFF
--- a/Heroes.ReplayParser/MPQFiles/ReplayServerBattlelobby.cs
+++ b/Heroes.ReplayParser/MPQFiles/ReplayServerBattlelobby.cs
@@ -66,8 +66,12 @@
 
                 // Now get the BattleTag for each player
                 var battleTagDigits = new List<char>();
-                foreach (var player in replay.Players.Where(i => i != null))
+                for (int playerNum = 0; playerNum < replay.Players.Count(); playerNum++)
                 {
+                    var player = replay.Players[playerNum];
+                    if (player == null)
+                        continue;
+
                     // Find each player's name, and then their associated BattleTag
                     battleTagDigits.Clear();
                     var playerNameBytes = Encoding.UTF8.GetBytes(player.Name);
@@ -86,13 +90,42 @@
                     }
 
                     // Get the numbers from the BattleTag
-                    while (!reader.EndOfStream)
+
+                    // if player is in slot 9, there's a chance that an extra digit could
+                    // be appended to the battleTag
+                    if (playerNum == 9)
                     {
-                        var currentCharacter = (char)reader.ReadByte();
-                        if (char.IsDigit(currentCharacter))
-                            battleTagDigits.Add(currentCharacter);
-                        else
-                            break;
+                        int count = 0;
+                        while (!reader.EndOfStream)
+                        {
+                            var currentCharacter = (char)reader.ReadByte();
+                            if (currentCharacter == 'z' || currentCharacter == 'Ø')
+                            {
+                                // removed previously digit
+                                battleTagDigits.RemoveAt(count - 1);
+                                break;
+                            }
+                            else if (char.IsDigit(currentCharacter))
+                            {
+                                battleTagDigits.Add(currentCharacter);
+                                count++;
+                            }
+                            else
+                            {
+                                break;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        while (!reader.EndOfStream)
+                        {
+                            var currentCharacter = (char)reader.ReadByte();
+                            if (char.IsDigit(currentCharacter))
+                                battleTagDigits.Add(currentCharacter);
+                            else
+                                break;
+                        }
                     }
 
                     if (reader.EndOfStream)


### PR DESCRIPTION
Sometimes when parsing for player's 9 BattleTag, an extra digit will be appended. This is a fix to remedy that situation.

For example, if your full BattleTag is Player#1234 and in the raw data, its Player#12345ØgU. After parsing it will be Player#12345.  After parsing through ~1600 of my replays it seems the character after the extra digit is a 'z' or a 'Ø'.  Might need a lot more replays to confirm if there's other characters besides those two after the extra digit.

Note: When I said player 9, it could actually be the last player in the replay.  That that will obviously only affect custom games.
