### PR TITLE
Updated ReplayMessageEvents parsing

### DIFF
--- a/Heroes.ReplayParser/DataParser.cs
+++ b/Heroes.ReplayParser/DataParser.cs
@@ -163,7 +163,7 @@ namespace Heroes.ReplayParser
                 }
 
             // Replay Message Events
-            // ReplayMessageEvents.Parse(replay, GetMpqFile(archive, ReplayMessageEvents.FileName));
+            //ReplayMessageEvents.Parse(replay, GetMpqFile(archive, ReplayMessageEvents.FileName), replay.ClientListByUserID);
 
             // Replay Resumable Events
             // So far it doesn't look like this file has anything we would be interested in

--- a/Heroes.ReplayParser/Heroes.ReplayParser.csproj
+++ b/Heroes.ReplayParser/Heroes.ReplayParser.csproj
@@ -68,6 +68,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DataParser.cs" />
+    <Compile Include="Message.cs" />
     <Compile Include="MPQFiles\ReplayResumableEvents.cs" />
     <Compile Include="Statistics.cs" />
     <Compile Include="Unit.cs" />

--- a/Heroes.ReplayParser/MPQFiles/ReplayMessageEvents.cs
+++ b/Heroes.ReplayParser/MPQFiles/ReplayMessageEvents.cs
@@ -1,146 +1,267 @@
 ﻿namespace Heroes.ReplayParser
 {
     using System;
-    using System.Collections.Generic;
     using System.IO;
-    using System.Linq;
     using System.Text;
 
-    /// <summary>
-    /// Handles all I/O involving the replay.message.events file, which contains in-game chat.
-    /// </summary>
     public class ReplayMessageEvents
     {
         public const string FileName = "replay.message.events";
 
         /// <summary> Parses the Replay.Messages.Events file. </summary>
         /// <param name="buffer"> Buffer containing the contents of the replay.messages.events file. </param>
-        /// <returns> A list of chat messages parsed from the buffer. </returns>
-        public static void Parse(Replay replay, byte[] buffer)
+        /// <returns> A list of messages parsed from the buffer. </returns>
+        public static void Parse(Replay replay, byte[] buffer, Player[] clientList)
         {
+            var ticksElapsed = 0;
             using (var stream = new MemoryStream(buffer))
             {
-                using (var reader = new BinaryReader(stream))
+                var bitReader = new Streams.BitReader(stream);
+
+                while (!bitReader.EndOfStream)
                 {
-                    int totalTime = 0;
-                    while (reader.BaseStream.Position < reader.BaseStream.Length)
+                    var message = new Message();
+
+                    ticksElapsed += (int)bitReader.Read(6 + (bitReader.Read(2) << 3));
+                    int playerIndex = (int)bitReader.Read(5);
+
+                    string playerName = string.Empty;
+                    string characterName = string.Empty;
+
+                    if (playerIndex != 16)
                     {
-                        // While not EOF
-                        var message = new ChatMessage();
-
-                        var time = ParseTimestamp(reader);
-
-                        // sometimes we only have a header for the message
-                        if (reader.BaseStream.Position >= reader.BaseStream.Length) 
-                            break;
-
-                        message.PlayerId = reader.ReadByte();
-
-                        // I believe this 'PlayerId' is an index for this client list, which can include observers
-                        // var player = replay.ClientList[message.PlayerId];
-
-                        totalTime += time;
-                        var opCode = reader.ReadByte();
-
-                        if (opCode == 0x80)
-                            reader.ReadBytes(4);
-                        else if (opCode == 0x83)
-                            reader.ReadBytes(8);
-                        else if (opCode == 2 && message.PlayerId <= 10)
-                        {
-                            if (message.PlayerId == 80)
-                                continue;
-
-                            message.MessageTarget = (ChatMessageTarget)(opCode & 7);
-                            var length = reader.ReadByte();
-
-                            if ((opCode & 8) == 8)
-                                length += 64;
-
-                            if ((opCode & 16) == 16)
-                                length += 128;
-
-                            message.Message = Encoding.UTF8.GetString(reader.ReadBytes(length));
-                        }
-                        else
-                        {
-                            
-                        }
-
-                        if (message.Message != null)
-                        {
-                            message.Timestamp = new TimeSpan(0, 0, (int)Math.Round(totalTime / 16.0));
-                            replay.ChatMessages.Add(message);
-                        }
+                        playerName = clientList[playerIndex].Name;
+                        characterName = clientList[playerIndex].Character;
                     }
+
+                    message.MessageEventType = (MessageEventType)bitReader.Read(4);
+                    switch (message.MessageEventType)
+                    {
+                        case MessageEventType.SChatMessage:
+                            {
+                                ChatMessage chatMessage = new ChatMessage();
+
+                                chatMessage.MessageTarget = (MessageTarget)bitReader.Read(3); // m_recipient (the target)
+                                chatMessage.Message = Encoding.UTF8.GetString(bitReader.ReadBlobPrecededWithLength(11)); // m_string
+
+                                chatMessage.Timestamp = new TimeSpan(0, 0, (int)Math.Round(ticksElapsed / 16.0));
+                                chatMessage.PlayerId = playerIndex;
+                                chatMessage.PlayerName = playerName;
+                                chatMessage.CharacterName = characterName;
+
+                                message.ChatMessage = chatMessage;
+                                replay.Messages.Add(message);
+                                break;
+                            }
+                        case MessageEventType.SPingMessage:
+                            {
+                                PingMessage pingMessage = new PingMessage();
+
+                                pingMessage.MessageTarget = (MessageTarget)bitReader.Read(3); // m_recipient (the target) 
+
+                                pingMessage.XCoordinate = bitReader.ReadInt32() - (-2147483648); // m_point x
+                                pingMessage.YCoordinate = bitReader.ReadInt32() - (-2147483648); // m_point y      
+
+                                pingMessage.Timestamp = new TimeSpan(0, 0, (int)Math.Round(ticksElapsed / 16.0));
+                                pingMessage.PlayerId = playerIndex;
+                                pingMessage.PlayerName = playerName;
+                                pingMessage.CharacterName = characterName;
+
+                                message.PingMessage = pingMessage;
+                                replay.Messages.Add(message);
+                                break;
+                            }
+                        case MessageEventType.SLoadingProgressMessage:
+                            {
+                                // can be used to keep track of how fast/slow players are loading
+                                // also includes players who are reloading the game
+                                var progress = bitReader.ReadInt32() - (-2147483648); // m_progress
+                                break;
+                            }
+                        case MessageEventType.SServerPingMessage:
+                            {
+                                break;
+                            }
+                        case MessageEventType.SReconnectNotifyMessage:
+                            {
+                                bitReader.Read(2); // m_status; is either a 1 or a 2
+                                break;
+                            }
+                        case MessageEventType.SPlayerAnnounceMessage:
+                            {
+                                PlayerAnnounceMessage announceMessage = new PlayerAnnounceMessage();
+
+                                announceMessage.AnnouncementType = (AnnouncementType)bitReader.Read(2);
+
+                                switch (announceMessage.AnnouncementType)
+                                {
+                                    case AnnouncementType.None:
+                                        {
+                                            break;
+                                        }
+                                    case AnnouncementType.Ability:
+                                        {
+                                            AbilityAnnouncment ability = new AbilityAnnouncment();
+                                            ability.AbilityLink = bitReader.ReadInt16(); // m_abilLink      
+                                            ability.AbilityIndex = (int)bitReader.Read(5); // m_abilCmdIndex
+                                            ability.ButtonLink = bitReader.ReadInt16(); // m_buttonLink
+
+                                            bitReader.ReadInt32(); // m_otherUnitTag
+                                            bitReader.ReadInt32(); // m_unitTag
+
+                                            announceMessage.AbilityAnnouncement = ability;
+                                            break;
+                                        }
+
+                                    case AnnouncementType.Behavior: // no idea what triggers this
+                                        {
+                                            bitReader.ReadInt16(); // m_behaviorLink
+                                            bitReader.ReadInt16(); // m_buttonLink
+
+                                            bitReader.ReadInt32(); // m_otherUnitTag
+                                            bitReader.ReadInt32(); // m_unitTag
+                                            break;
+                                        }
+                                    case AnnouncementType.Vitals:
+                                        {
+                                            VitalAnnouncment vital = new VitalAnnouncment();
+                                            vital.VitalType = (VitalType)(bitReader.ReadInt16() - (-32768));
+
+                                            bitReader.ReadInt32(); // m_otherUnitTag
+                                            bitReader.ReadInt32(); // m_unitTag
+
+                                            announceMessage.VitalAnnouncement = vital;
+                                            break;
+                                        }
+                                    default:
+                                        throw new NotImplementedException();
+                                }
+
+                                announceMessage.Timestamp = new TimeSpan(0, 0, (int)Math.Round(ticksElapsed / 16.0));
+                                announceMessage.PlayerId = playerIndex;
+                                announceMessage.PlayerName = playerName;
+                                announceMessage.CharacterName = characterName;
+
+                                message.PlayerAnnounceMessage = announceMessage;
+                                replay.Messages.Add(message);
+                                break;
+                            }
+                        default:
+                            throw new NotImplementedException();
+                    }
+
+                    bitReader.AlignToByte();
                 }
             }
         }
 
-        /// <summary> Reads a Timestamp object, returning the value and incrementing the reader. </summary>
-        /// <param name="reader"> The reader, at the position of the Timestamp object.  </param>
-        /// <returns> The integer value in the timestamp object.  </returns>
-        internal static int ParseTimestamp(BinaryReader reader)
+        public enum MessageEventType
         {
-            byte one = reader.ReadByte();
-            if ((one & 3) > 0)
+            SChatMessage = 0,
+            SPingMessage = 1,
+            SLoadingProgressMessage = 2,
+            SServerPingMessage = 3,
+            SReconnectNotifyMessage = 4,
+            SPlayerAnnounceMessage = 5
+        }
+
+        // m_announcement
+        public enum AnnouncementType
+        {
+            None = 0,
+            Ability = 1,
+            Behavior = 2,
+            Vitals = 3
+        }
+
+        public enum MessageTarget
+        {
+            All = 0,
+            Allies = 1,
+            //Observers = ?,
+
+            // party? private?
+        }
+
+        public enum VitalType
+        {
+            Health = 0,
+            Mana = 2 // also includes Fury and Brew
+        }
+
+        public class AbilityAnnouncment
+        {
+            public int AbilityIndex { get; set; }
+            public int AbilityLink { get; set; }
+            public int ButtonLink { get; set; }
+        }
+
+        public class BehaviorAnnouncment
+        { }
+
+        public class VitalAnnouncment
+        {
+            public VitalType VitalType { get; set; }
+        }
+
+        public class ChatMessage
+        {
+            public int PlayerId { get; set; }
+            public string PlayerName { get; set; }
+            public string CharacterName { get; set; }
+            public MessageTarget MessageTarget { get; set; }
+            public string Message { get; set; }
+            public TimeSpan Timestamp { get; set; }
+            public override string ToString()
             {
-                int two = reader.ReadByte();
-                two = (short)(((one >> 2) << 8) | two);
+                if (!string.IsNullOrEmpty(CharacterName))
+                    return $"({Timestamp}) [{MessageTarget}] {PlayerName} ({CharacterName}): {Message}";
+                else
+                    return $"({Timestamp}) [{MessageTarget}] {PlayerName}: {Message}";
 
-                if ((one & 3) >= 2)
-                {
-                    var tmp = reader.ReadByte();
-                    two = (two << 8) | tmp;
-
-                    if ((one & 3) == 3)
-                    {
-                        tmp = reader.ReadByte();
-                        two = (two << 8) | tmp;
-                    }
-                }
-
-                return two;
             }
-
-            return one >> 2;
         }
-    }
 
-    /// <summary>
-    /// Defines a single line of text in a replay's conversation log.
-    /// </summary>
-    public class ChatMessage
-    {
-        /// <summary> Gets or sets the chat message. </summary>
-        public string Message { get; set; }
-
-        /// <summary> Gets or sets the target of the message. </summary>
-        public ChatMessageTarget MessageTarget { get; set; }
-
-        /// <summary> Gets or sets the Player Id who spoke the message. </summary>
-        public int PlayerId { get; set; }
-
-        /// <summary> Gets or sets the timestamp at which point the message was displayed. </summary>
-        public TimeSpan Timestamp { get; set; }
-
-        /// <summary> Overrides the ToString method, to display the chat message similar to what's expected in-game. </summary>
-        /// <returns> Returns a chat message formatted similar to the in-game chat log. </returns>
-        public override string ToString()
+        // Ping messages include normal pings (no target), targeted pings (such as Player 1 wants to help Player 2), retreat,
+        // and the more ping options (on my way, defend, danger, assist)
+        // does not include captured camps, hearthing
+        // no way to tell which one is which
+        public class PingMessage
         {
-            return string.Format("({0}) [{1}] Player {2}: {3}", this.Timestamp, this.MessageTarget, this.PlayerId, this.Message);
+            public int PlayerId { get; set; }
+            public string PlayerName { get; set; }
+            public string CharacterName { get; set; }
+            public MessageTarget MessageTarget { get; set; }
+            public int XCoordinate { get; set; }
+            public int YCoordinate { get; set; }
+            public TimeSpan Timestamp { get; set; }
+
+            public override string ToString()
+            {
+                if (!string.IsNullOrEmpty(CharacterName))
+                    return $"({Timestamp}) [{MessageTarget}] {PlayerName} ({CharacterName}) used a ping";
+                else
+                    return $"({Timestamp}) [{MessageTarget}] {PlayerName} used a ping";
+            }
         }
-    }
 
-    public enum ChatMessageTarget
-    {
-        /// <summary> Chat message delivered to all players. </summary>
-        All = 0,
-
-        /// <summary> Chat message only delivered to allied players. </summary>
-        Allies = 2,
-
-        /// <summary> Chat message delivered to observers. </summary>
-        Observers = 4,
+        public class PlayerAnnounceMessage
+        {
+            public int PlayerId { get; set; }
+            public string PlayerName { get; set; }
+            public string CharacterName { get; set; }
+            public AbilityAnnouncment AbilityAnnouncement { get; set; }
+            public BehaviorAnnouncment BehaviorAnnouncement { get; set; }
+            public VitalAnnouncment VitalAnnouncement { get; set; }
+            public AnnouncementType AnnouncementType { get; set; }
+            public TimeSpan Timestamp { get; set; }
+            public override string ToString()
+            {
+                if (!string.IsNullOrEmpty(CharacterName))
+                    return $"({Timestamp}) {PlayerName} ({CharacterName}) announced {AnnouncementType}";
+                else
+                    return $"({Timestamp}) {PlayerName} announced {AnnouncementType}";
+            }
+        }
     }
 }

--- a/Heroes.ReplayParser/Message.cs
+++ b/Heroes.ReplayParser/Message.cs
@@ -1,0 +1,24 @@
+﻿using static Heroes.ReplayParser.ReplayMessageEvents;
+
+namespace Heroes.ReplayParser
+{
+    public class Message
+    {
+        public MessageEventType MessageEventType { get; set; }
+        public ChatMessage ChatMessage { get; set; }
+        public PingMessage PingMessage { get; set; }
+        public PlayerAnnounceMessage PlayerAnnounceMessage { get; set; }
+
+        public override string ToString()
+        {
+            if (ChatMessage != null)
+                return ChatMessage.ToString();
+            else if (PingMessage != null)
+                return PingMessage.ToString();
+            else if (PlayerAnnounceMessage != null)
+                return PlayerAnnounceMessage.ToString();
+            else
+                return base.ToString();
+        }
+    }
+}

--- a/Heroes.ReplayParser/Replay.cs
+++ b/Heroes.ReplayParser/Replay.cs
@@ -5,8 +5,8 @@
 
     public class Replay
     {
-        /// <summary> Gets a list of all chat messages which took place during the game. </summary>
-        public List<ChatMessage> ChatMessages { get; set; } = new List<ChatMessage>();
+        /// <summary> Gets a list of all messages which took place during the game. </summary>
+        public List<Message> Messages { get; set; } = new List<Message>();
 
         /// <summary> Gets the speed the game was played at. </summary>
         public GameSpeed GameSpeed { get; set; }


### PR DESCRIPTION
Messages that will be save include chat, pings, and announcements.
Tested over ~2000 replays, all successfully parsed, at least back to replay build 39445.  No hardcoded build statements were used, so the parsing should be successful for builds <39445.

By default, in DataParser.cs, the ReplayMessageEvents.Parse() is commented out.
