### PR TITLE
Changed reference path for MpqTool

### DIFF
--- a/Heroes.ReplayParser/Heroes.ReplayParser.csproj
+++ b/Heroes.ReplayParser/Heroes.ReplayParser.csproj
@@ -87,7 +87,7 @@
     <Compile Include="BitReader.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\MpqTool\MpqTool.csproj">
+    <ProjectReference Include="..\MpqTool\MpqTool.csproj">
       <Project>{fa50e172-836b-47bb-8745-60595e4fb12a}</Project>
       <Name>MpqTool</Name>
     </ProjectReference>


### PR DESCRIPTION
My Visual Studio is changing that path on build, so its annoying when having to commit.
