### PR TITLE
New data added in the usable skins/hero section

### DIFF
--- a/Heroes.ReplayParser/MPQFiles/ReplayServerBattlelobby.cs
+++ b/Heroes.ReplayParser/MPQFiles/ReplayServerBattlelobby.cs
@@ -147,13 +147,14 @@
 
                 // All the Heroes, skins, mounts, effects, some other weird stuff (Cocoon, ArtifactSlot2, TestMountRideSurf, etc...)
                 // --------------------------------------------------------------
+                List<string> skins = new List<string>();
                 int skinArrayLength = bitReader.ReadInt32();
+
                 for (int i = 0; i < skinArrayLength; i++)
                 {
-                    bitReader.ReadString(bitReader.ReadByte()); // the name of the "skin"
+                    skins.Add(bitReader.ReadString(bitReader.ReadByte()));
                 }
 
-                // this next part is just a whole bunch of 0x00 and 0x01
                 // use to determine if the heroes, skins, mounts are usable by the player (owns/free to play/internet cafe)
                 if (bitReader.ReadInt32() != skinArrayLength)
                     throw new Exception("skinArrayLength not equal");
@@ -163,21 +164,33 @@
                     for (int j = 0; j < 16; j++) // 16 is total player slots
                     {
                         ReadByte0x00(bitReader);
+
+                        // new values beginning on ptr 47801
+                        // 0xC3 = free to play?
+                        // more values: 0xC1, 0x02, 0x83
                         var num = bitReader.Read(8);
-                        if (num == 1)
-                        { } // true;                          
-                        else if (num == 0)
-                        { } // false;                          
-                        else
-                            throw new NotImplementedException();
+                        if (replay.ClientListByUserID[j] != null)
+                        {
+                            if (num > 0)
+                            {
+                                // usable
+                            }
+                            else if (num == 0)
+                            {
+                                // not usable
+                            }
+                            else
+                                throw new NotImplementedException();
+                        }
                     }
                 }
 
                 // Player info 
                 // ------------------------
-                if (replay.ReplayBuild <= 43259)
+                if (replay.ReplayBuild <= 43259 || replay.ReplayBuild == 47801)
                 {
                     // Builds that are not yet supported for detailed parsing
+                    // build 47801 is a ptr build that had new data in the battletag section, the data was changed in 47944 (patch for 47801)
                     GetBattleTags(replay, bitReader);
                     return;
                 }
@@ -187,34 +200,22 @@
 
                 ReadByte0x00(bitReader);
                 ReadByte0x00(bitReader);
-                bitReader.ReadByte();  // why 0x19?
+                bitReader.ReadByte(); // 0x19
 
-                if (replay.ReplayBuild < 47479)
+                if (replay.ReplayBuild <= 47479 || replay.ReplayBuild == 47903)
                 {
                     ExtendedBattleTagParsingOld(replay, bitReader);
                     return;
                 }
-                else if (replay.ReplayBuild == 47479)
-                {
-                    // build 47479, after November 2, 2016 around 7pm CDT the data in this section changed slightly
-                    // there is no longer a duplicated TId
-                    if (!DetectBattleTagChangeBuild47479(replay, bitReader))
-                    {
-                        ExtendedBattleTagParsingOld(replay, bitReader);
-                        return;
-                    }
-                }
 
-                // for builds after 47479
-                for (int i = 0; i < replay.ClientListByUserID.Length; i++)
+                for (int player = 0; player < replay.ClientListByUserID.Length; player++)
                 {
-                    if (replay.ClientListByUserID[i] == null)
+                    if (replay.ClientListByUserID[player] == null)
                         break;
 
                     string TId;
 
-                    // this first one is weird, nothing to indicate the length of the string
-                    if (i == 0)
+                    if (player == 0)
                     {
                         var offset = bitReader.ReadByte();
                         bitReader.ReadString(2); // T:
@@ -231,12 +232,28 @@
                         TId = Encoding.UTF8.GetString(ReadSpecialBlob(bitReader, 8));
                     }
 
-                    // next 31 bytes
+                    // next 30 bytes
                     bitReader.ReadBytes(4); // same for all players
                     bitReader.ReadBytes(14);
-                    bitReader.ReadBytes(13); // same for all players
+                    bitReader.ReadBytes(12); // same for all players
 
-                    bitReader.ReadBytes(40);
+                    // these were important in ptr build 47801, not sure what it's used for now
+                    // each byte has a max value of 0x7F (127)
+                    bitReader.ReadBytes(4);
+
+                    // this data is a repeat of the usable skins section above
+                    //bitReader.stream.Position = bitReader.stream.Position = bitReader.stream.Position + (skinArrayLength * 2);
+                    for (int i = 0; i < skinArrayLength; i++)
+                    {
+                        // each byte has a max value of 0x7F (127)
+                        int value = 0;
+                        int x = (int)bitReader.Read(8);
+                        if (x > 0)
+                        {
+                            value += x + 127;
+                        }
+                        value += (int)bitReader.Read(8);
+                    }
 
                     bitReader.Read(1);
 
@@ -251,25 +268,27 @@
                     bitReader.Read(1);
                     var battleTag = Encoding.UTF8.GetString(bitReader.ReadBlobPrecededWithLength(7)).Split('#'); // battleTag <name>#xxxxx
 
-                    if (battleTag.Length != 2 || battleTag[0] != replay.ClientListByUserID[i].Name)
+                    if (battleTag.Length != 2 || battleTag[0] != replay.ClientListByUserID[player].Name)
                         throw new Exception("Couldn't find BattleTag");
 
-                    replay.ClientListByUserID[i].BattleTag = int.Parse(battleTag[1]);
+                    replay.ClientListByUserID[player].BattleTag = int.Parse(battleTag[1]);
 
                     // these similar bytes don't occur for last player
                     bitReader.ReadBytes(27);
                 }
 
-                // some more bytes after (at least 700)
-                // theres some HeroICONs and other repetitive stuff
-                // --------------------------------
+                // some more data after this
             }
         }
 
-        // use before build 47479 and for some builds of 47479
-        // call DetectBattleTagChangeBuild47479 to determine if this method should be use for build 47479
+        // used for builds <= 47479 and 47903
         private static void ExtendedBattleTagParsingOld(Replay replay, BitReader bitReader)
         {
+            bool changed47479 = false;
+
+            if (replay.ReplayBuild == 47479 && DetectBattleTagChangeBuild47479(replay, bitReader))
+                changed47479 = true;
+
             for (int i = 0; i < replay.ClientListByUserID.Length; i++)
             {
                 if (replay.ClientListByUserID[i] == null)
@@ -285,21 +304,20 @@
                     bitReader.ReadString(2); // T:
                     TId = bitReader.ReadString(12 + offset);
 
-                    //$"T:{TId}";
+                    if (replay.ReplayBuild <= 47479 && !changed47479)
+                    {
+                        bitReader.ReadBytes(6);
+                        ReadByte0x00(bitReader);
+                        ReadByte0x00(bitReader);
+                        ReadByte0x00(bitReader);
+                        bitReader.Read(6);
 
-                    bitReader.ReadBytes(6);
-                    ReadByte0x00(bitReader);
-                    ReadByte0x00(bitReader);
-                    ReadByte0x00(bitReader);
-                    bitReader.Read(6);
+                        // get T: again
+                        TId_2 = Encoding.UTF8.GetString(ReadSpecialBlob(bitReader, 8));
 
-                    // get T: again
-                    TId_2 = Encoding.UTF8.GetString(ReadSpecialBlob(bitReader, 8));
-
-                    if (TId != TId_2)
-                        throw new Exception("TID dup not equal");
-
-                    //$"T:{TId}";
+                        if (TId != TId_2)
+                            throw new Exception("TID dup not equal");
+                    }
                 }
                 else
                 {
@@ -311,19 +329,20 @@
                     // get XXXXXXXX#YYY
                     TId = Encoding.UTF8.GetString(ReadSpecialBlob(bitReader, 8));
 
-                    bitReader.ReadBytes(6);
-                    ReadByte0x00(bitReader);
-                    ReadByte0x00(bitReader);
-                    ReadByte0x00(bitReader);
-                    bitReader.Read(6);
+                    if (replay.ReplayBuild <= 47479 && !changed47479)
+                    {
+                        bitReader.ReadBytes(6);
+                        ReadByte0x00(bitReader);
+                        ReadByte0x00(bitReader);
+                        ReadByte0x00(bitReader);
+                        bitReader.Read(6);
 
-                    // get T: again
-                    TId_2 = Encoding.UTF8.GetString(ReadSpecialBlob(bitReader, 8));
+                        // get T: again
+                        TId_2 = Encoding.UTF8.GetString(ReadSpecialBlob(bitReader, 8));
 
-                    if (TId != TId_2)
-                        throw new Exception("TID dup not equal");
-
-                    //$"T:{TId}";
+                        if (TId != TId_2)
+                            throw new Exception("TID dup not equal");
+                    }
                 }
 
                 // next 31 bytes
@@ -334,7 +353,9 @@
 
                 bitReader.ReadBytes(14); // same for all players
 
-                if (replay.ReplayBuild >= 47219 || replay.ReplayBuild == 47024)
+                if (replay.ReplayBuild >= 47903 || changed47479)
+                    bitReader.ReadBytes(40);
+                else if (replay.ReplayBuild >= 47219 || replay.ReplayBuild == 47024)
                     bitReader.ReadBytes(39);
                 else if (replay.ReplayBuild >= 45889)
                     bitReader.ReadBytes(38);
@@ -345,8 +366,9 @@
                 else
                     bitReader.ReadBytes(35);
 
-
-                if (replay.ReplayBuild >= 47219 || replay.ReplayBuild == 47024)
+                if (replay.ReplayBuild >= 47903 || changed47479)
+                    bitReader.Read(1);
+                else if (replay.ReplayBuild >= 47219 || replay.ReplayBuild == 47024)
                     bitReader.Read(6);
                 else if (replay.ReplayBuild >= 46690 || replay.ReplayBuild == 46416)
                     bitReader.Read(5);
@@ -384,6 +406,9 @@
         // Detect the change that happended in build 47479 on November 2, 2016
         private static bool DetectBattleTagChangeBuild47479(Replay replay, BitReader bitReader)
         {
+            if (replay.ReplayBuild != 47479)
+                return false;
+
             bool changed = false;
 
             var offset = bitReader.ReadByte();
@@ -513,7 +538,8 @@
             }
 
             // Find player BattleTags using Regex
-            replay.Players = Regex.Matches(stringData, @"(\p{L}|\d){3,24}#\d{4,10}[zØ]?").Cast<Match>().Select(i => i.Value.Split('#')).Select(i => new Player {
+            replay.Players = Regex.Matches(stringData, @"(\p{L}|\d){3,24}#\d{4,10}[zØ]?").Cast<Match>().Select(i => i.Value.Split('#')).Select(i => new Player
+            {
                 Name = i[0],
                 BattleTag = int.Parse(i[1].Last() == 'z' || i[1].Last() == 'Ø' ? i[1].Substring(0, i[1].Length - 2) : i[1]),
                 BattleNetRegionId = playerBattleNetRegionId
@@ -534,13 +560,16 @@
 
         public static Replay Base64DecodeStandaloneBattlelobby(string base64EncodedData)
         {
-            return new Replay {
-                Players = Encoding.UTF8.GetString(Convert.FromBase64String(base64EncodedData)).Split(',').Select(i => i.Split('#')).Select(i => new Player {
+            return new Replay
+            {
+                Players = Encoding.UTF8.GetString(Convert.FromBase64String(base64EncodedData)).Split(',').Select(i => i.Split('#')).Select(i => new Player
+                {
                     Name = i[1],
                     BattleTag = int.Parse(i[2]),
                     BattleNetRegionId = int.Parse(i[0]),
                     Team = int.Parse(i[3])
-                }).ToArray() };
+                }).ToArray()
+            };
         }
     }
 }

--- a/Heroes.ReplayParser/MPQFiles/ReplayServerBattlelobby.cs
+++ b/Heroes.ReplayParser/MPQFiles/ReplayServerBattlelobby.cs
@@ -148,7 +148,16 @@
                 // All the Heroes, skins, mounts, effects, some other weird stuff (Cocoon, ArtifactSlot2, TestMountRideSurf, etc...)
                 // --------------------------------------------------------------
                 List<string> skins = new List<string>();
-                int skinArrayLength = bitReader.ReadInt32();
+
+                int skinArrayLength = 0;
+
+                if (replay.ReplayBuild >= 48027)
+                    skinArrayLength = bitReader.ReadInt16();
+                else 
+                    skinArrayLength = bitReader.ReadInt32();
+
+                if (skinArrayLength > 1000)
+                    throw new Exception("skinArrayLength is an unusually large number");
 
                 for (int i = 0; i < skinArrayLength; i++)
                 {
@@ -163,7 +172,7 @@
                 {
                     for (int j = 0; j < 16; j++) // 16 is total player slots
                     {
-                        ReadByte0x00(bitReader);
+                        bitReader.ReadByte();
 
                         // new values beginning on ptr 47801
                         // 0xC3 = free to play?
@@ -239,7 +248,10 @@
 
                     // these were important in ptr build 47801, not sure what it's used for now
                     // each byte has a max value of 0x7F (127)
-                    bitReader.ReadBytes(4);
+                    if (replay.ReplayBuild >= 48027)
+                        bitReader.ReadInt16();
+                    else
+                        bitReader.ReadInt32();
 
                     // this data is a repeat of the usable skins section above
                     //bitReader.stream.Position = bitReader.stream.Position = bitReader.stream.Position + (skinArrayLength * 2);


### PR DESCRIPTION
**Do not accept this pull request yet. I need to confirm some results after the patch goes live** 

PTR build 47801 changed the data in the usable skins section (the section after all the heroes/skins with all the 0x00 and 0x01).  
There is no longer any 0x01 but different values if the hero/skin is usable.  I've seen 0xC3, 0xC1, 0x02, 0x83. 0xC3 seems to indicate its Free to Play. I'm not sure what the other values mean.  If you have time, it'll be helpful to find out what the other values mean. 
It will probably help to wait until PTR goes live, since almost every hero is Free to Play, thus most values are 0xC3.

New data was added in the battletag section as well.  However, the added data was changed in PTR patch build 47944.
I've figured out that the added data (in 47944) is just a repeat of the usable skins section's data, although its in a different data format.