### PR TITLE
Add netstandard projects

### DIFF
--- a/Heroes.ReplayParser.ConsoleApplication/ConsoleApplication1/ConsoleApplication1.netcore.csproj
+++ b/Heroes.ReplayParser.ConsoleApplication/ConsoleApplication1/ConsoleApplication1.netcore.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Heroes.ReplayParser\Heroes.ReplayParser.netstandard.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Heroes.ReplayParser.ConsoleApplication/ConsoleApplication1/ConsoleApplication1.netcore.sln
+++ b/Heroes.ReplayParser.ConsoleApplication/ConsoleApplication1/ConsoleApplication1.netcore.sln
@@ -1,0 +1,49 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.16
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsoleApplication1.netcore", "ConsoleApplication1.netcore.csproj", "{861DB181-6C12-48CB-AA2A-19B374ECA319}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Heroes.ReplayParser.netstandard", "..\..\Heroes.ReplayParser\Heroes.ReplayParser.netstandard.csproj", "{AAF78D53-A1DA-424A-B1AA-09895EAB3B2B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MpqTool.netstandard", "..\..\MpqTool\MpqTool.netstandard.csproj", "{FA50E172-836B-47BB-8745-60595E4FB12A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{861DB181-6C12-48CB-AA2A-19B374ECA319}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{861DB181-6C12-48CB-AA2A-19B374ECA319}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{861DB181-6C12-48CB-AA2A-19B374ECA319}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{861DB181-6C12-48CB-AA2A-19B374ECA319}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{861DB181-6C12-48CB-AA2A-19B374ECA319}.Release|Any CPU.Build.0 = Release|Any CPU
+		{861DB181-6C12-48CB-AA2A-19B374ECA319}.Release|x86.ActiveCfg = Release|Any CPU
+		{AAF78D53-A1DA-424A-B1AA-09895EAB3B2B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AAF78D53-A1DA-424A-B1AA-09895EAB3B2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AAF78D53-A1DA-424A-B1AA-09895EAB3B2B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AAF78D53-A1DA-424A-B1AA-09895EAB3B2B}.Debug|x86.Build.0 = Debug|Any CPU
+		{AAF78D53-A1DA-424A-B1AA-09895EAB3B2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AAF78D53-A1DA-424A-B1AA-09895EAB3B2B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AAF78D53-A1DA-424A-B1AA-09895EAB3B2B}.Release|x86.ActiveCfg = Release|Any CPU
+		{AAF78D53-A1DA-424A-B1AA-09895EAB3B2B}.Release|x86.Build.0 = Release|Any CPU
+		{FA50E172-836B-47BB-8745-60595E4FB12A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FA50E172-836B-47BB-8745-60595E4FB12A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FA50E172-836B-47BB-8745-60595E4FB12A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FA50E172-836B-47BB-8745-60595E4FB12A}.Debug|x86.Build.0 = Debug|Any CPU
+		{FA50E172-836B-47BB-8745-60595E4FB12A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FA50E172-836B-47BB-8745-60595E4FB12A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FA50E172-836B-47BB-8745-60595E4FB12A}.Release|x86.ActiveCfg = Release|Any CPU
+		{FA50E172-836B-47BB-8745-60595E4FB12A}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {DE6A4729-7EED-4A36-9A0C-987CFD2BEBC2}
+	EndGlobalSection
+EndGlobal

--- a/Heroes.ReplayParser/Heroes.ReplayParser.netstandard.csproj
+++ b/Heroes.ReplayParser/Heroes.ReplayParser.netstandard.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MpqTool\MpqTool.netstandard.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+
+</Project>

--- a/MpqTool/MpqTool.netstandard.csproj
+++ b/MpqTool/MpqTool.netstandard.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SharpZipLib" Version="1.0.0-alpha2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Added separate projects and solution that target .Net Standard. This should avoid any conflicts with existing apps and add netcore support in a clean and maintainable way.