### PR TITLE
Added map alternative name

### DIFF
--- a/Heroes.ReplayParser/Replay.cs
+++ b/Heroes.ReplayParser/Replay.cs
@@ -17,6 +17,9 @@
         /// <summary> Gets the map the game was played on. </summary>
         public string Map { get; set; }
 
+        /// <summary> Gets the alternative name of the map </summary>
+        public string MapAlternativeName { get; set; }
+
         /// <summary> Gets the size of the map the game was played on. </summary>
         public Point MapSize { get; set; }
 

--- a/Heroes.ReplayParser/Statistics.cs
+++ b/Heroes.ReplayParser/Statistics.cs
@@ -222,6 +222,8 @@ namespace Heroes.ReplayParser
                                 break;
 
                             case "EndOfGameTalentChoices": // {StatGameEvent: {"EndOfGameTalentChoices", [{{"Hero"}, "HeroAbathur"}, {{"Win/Loss"}, "Win"}, {{"Map"}, "HauntedWoods"}, {{"Tier 1 Choice"}, "AbathurMasteryRegenerativeMicrobes"}, {{"Tier 2 Choice"}, "AbathurSymbioteCarapaceSustainedCarapace"}, {{"Tier 3 Choice"}, "AbathurMasteryNeedlespine"}, {{"Tier 4 Choice"}, "AbathurHeroicAbilityUltimateEvolution"}, {{"Tier 5 Choice"}, "AbathurSymbioteSpikeBurstSomaTransference"}, {{"Tier 6 Choice"}, "AbathurVolatileMutation"}, {{"Tier 7 Choice"}, "AbathurMasteryLocustMaster"}], [{{"PlayerID"}, 1}, {{"Level"}, 24}], }}
+                                if (string.IsNullOrEmpty(replay.MapAlternativeName) && trackerEvent.Data.dictionary[1].optionalData.array.Length > 2)
+                                    replay.MapAlternativeName = trackerEvent.Data.dictionary[1].optionalData.array[2].dictionary[1].blobText; // map name
                                 break;
 
                             case "TalentChosen": // {StatGameEvent: {"TalentChosen", [{{"PurchaseName"}, "NovaCombatStyleAdvancedCloaking"}], [{{"PlayerID"}, 6}], }}


### PR DESCRIPTION
Adds the alt/internal name of the map.  This name can be used to identify the map since it is not localized.