### PR TITLE
Fix replay version

### DIFF
--- a/Heroes.ReplayParser/MPQFiles/MpqHeader.cs
+++ b/Heroes.ReplayParser/MPQFiles/MpqHeader.cs
@@ -37,9 +37,9 @@
 
             // [0] = Blob, "Heroes of the Storm replay 11" - Strange backward arrow before 11 as well.  I don't think the '11' will change, as I believe it was also always '11' in Starcraft 2 replays.
 
-            replay.ReplayVersion = string.Format("{0}.{1}.{2}.{3}", headerStructure.dictionary[1].dictionary[0].vInt.Value, headerStructure.dictionary[1].dictionary[1].vInt.Value, headerStructure.dictionary[1].dictionary[2].vInt.Value, headerStructure.dictionary[1].dictionary[3].vInt.Value);
+            replay.ReplayVersion = string.Format("{0}.{1}.{2}.{3}", headerStructure.dictionary[1].dictionary[1].vInt.Value, headerStructure.dictionary[1].dictionary[2].vInt.Value, headerStructure.dictionary[1].dictionary[3].vInt.Value, headerStructure.dictionary[1].dictionary[4].vInt.Value);
 
-			replay.ReplayBuild = (int)headerStructure.dictionary[1].dictionary[4].vInt.Value;
+            replay.ReplayBuild = (int)headerStructure.dictionary[1].dictionary[4].vInt.Value;
 
 			if(replay.ReplayBuild >= 51978)
 				replay.ReplayVersionMajor = (int)headerStructure.dictionary[1].dictionary[1].vInt.Value;


### PR DESCRIPTION
This has always been wrong. 
`headerStructure.dictionary[1].dictionary[0].vInt.Value` is `m_flag`, the major version is the next index `headerStructure.dictionary[1].dictionary[1].vInt.Value`

Before 51978, the major version would always be 0.