### PR TITLE
Delegate | File lock bug fix

### DIFF
--- a/Heroes.ReplayParser/MPQFiles/MpqHeader.cs
+++ b/Heroes.ReplayParser/MPQFiles/MpqHeader.cs
@@ -13,7 +13,7 @@
         /// <param name="filename">Filename of the file to open.</param>
         public static void ParseHeader(Replay replay, string filename)
         {
-            using (var fileStream = new FileStream(filename, FileMode.Open))
+            using (var fileStream = new FileStream(filename, FileMode.Open, FileAccess.Read))
                 using (var reader = new BinaryReader(fileStream))
                     ParseHeader(replay, reader);
         }


### PR DESCRIPTION
- ParseHeader should request Read access only.
- Not providing the FileAccess.Read defaults it to FileAccess.ReadWrite
- https://source.dot.net/#System.Private.CoreLib/FileStream.cs,167