### PR TITLE
Updated for the case of no battle tag for a player

### DIFF
--- a/Heroes.ReplayParser/MPQFiles/ReplayServerBattlelobby.cs
+++ b/Heroes.ReplayParser/MPQFiles/ReplayServerBattlelobby.cs
@@ -233,10 +233,11 @@ namespace Heroes.ReplayParser.MPQFiles
 
                 var battleTag = Encoding.UTF8.GetString(bitReader.ReadBlobPrecededWithLength(7)).Split('#'); // battleTag <name>#xxxxx
 
-                if (battleTag.Length != 2 || battleTag[0] != replay.ClientListByUserID[i].Name)
+                if (battleTag[0] != replay.ClientListByUserID[i].Name)
                     throw new DetailedParsedException("Couldn't find BattleTag");
 
-                replay.ClientListByUserID[i].BattleTag = int.Parse(battleTag[1]);
+                if (battleTag.Length == 2)
+                    replay.ClientListByUserID[i].BattleTag = int.Parse(battleTag[1]);
 
                 if (replay.ReplayBuild >= 52860 || (replay.ReplayVersionMajor == 2 && replay.ReplayBuild >= 51978))
                     replay.ClientListByUserID[i].AccountLevel = (int)bitReader.Read(32);  // in custom games, this is a 0

--- a/Heroes.ReplayParser/Player.cs
+++ b/Heroes.ReplayParser/Player.cs
@@ -48,7 +48,7 @@ namespace Heroes.ReplayParser
         /// <summary>
         /// Gets or sets the BattleTag (Numbers only)
         /// </summary>
-        public int? BattleTag { get; set; } = null;
+        public int BattleTag { get; set; }
 
         /// <summary>
         /// Gets or sets the type of player, whether he is human or computer.

--- a/Heroes.ReplayParser/Player.cs
+++ b/Heroes.ReplayParser/Player.cs
@@ -48,7 +48,7 @@ namespace Heroes.ReplayParser
         /// <summary>
         /// Gets or sets the BattleTag (Numbers only)
         /// </summary>
-        public int BattleTag { get; set; }
+        public int? BattleTag { get; set; } = null;
 
         /// <summary>
         /// Gets or sets the type of player, whether he is human or computer.


### PR DESCRIPTION
[Cursed Hollow_NoBattleTag.zip](https://github.com/barrett777/Heroes.ReplayParser/files/4094640/Cursed.Hollow_NoBattleTag.zip)

This updates the full battlelobby parsing to account for player's with no battletag, however the other simple methods to obtains only the battletag do not work.

`GetBattleTags()` will get random digits for the number tag of the no-name player.  
`StandaloneBattleLobbyParser.Parse()` will get x-1 players.

No idea how to want to fix these, but you could always look the TID and work from there I guess.

